### PR TITLE
feat(ui): onboarding, navigation, and anti-bypass UX pass

### DIFF
--- a/app/src/main/java/com/andebugulin/nfcguard/ui/GuardianViewModel.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/GuardianViewModel.kt
@@ -38,6 +38,11 @@ class GuardianViewModel(application: Application) : AndroidViewModel(application
     private val _safeRegimeEnabled = MutableStateFlow(true)
     val safeRegimeEnabled: StateFlow<Boolean> = _safeRegimeEnabled
 
+    /** Anti-bypass challenge wait time, in seconds. Floor is 90s (raise-only) so
+     *  it can be made harder but never weakened. Stored separately from AppState. */
+    private val _challengeDurationSeconds = MutableStateFlow(CHALLENGE_MIN_SECONDS)
+    val challengeDurationSeconds: StateFlow<Int> = _challengeDurationSeconds
+
     /** Pending NFC unlock awaiting user duration choice */
     private val _pendingUnlock = MutableStateFlow<PendingUnlock?>(null)
     val pendingUnlock: StateFlow<PendingUnlock?> = _pendingUnlock
@@ -47,6 +52,9 @@ class GuardianViewModel(application: Application) : AndroidViewModel(application
         // can't disable the safety challenge). Direct prefs access.
         val prefs = context.getSharedPreferences("guardian_prefs", Context.MODE_PRIVATE)
         _safeRegimeEnabled.value = prefs.getBoolean("safe_regime_enabled", true)
+        _challengeDurationSeconds.value =
+            prefs.getInt("safe_regime_challenge_seconds", CHALLENGE_MIN_SECONDS)
+                .coerceAtLeast(CHALLENGE_MIN_SECONDS)
 
         ensureServiceRunning()
 
@@ -72,6 +80,15 @@ class GuardianViewModel(application: Application) : AndroidViewModel(application
         _safeRegimeEnabled.value = enabled
         val prefs = context.getSharedPreferences("guardian_prefs", Context.MODE_PRIVATE)
         prefs.edit().putBoolean("safe_regime_enabled", enabled).apply()
+    }
+
+    /** Set the anti-bypass challenge wait time. Coerced to the [CHALLENGE_MIN_SECONDS]
+     *  floor so users can lengthen the challenge but never shorten it below 1:30. */
+    fun setChallengeDurationSeconds(seconds: Int) {
+        val coerced = seconds.coerceAtLeast(CHALLENGE_MIN_SECONDS)
+        _challengeDurationSeconds.value = coerced
+        val prefs = context.getSharedPreferences("guardian_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putInt("safe_regime_challenge_seconds", coerced).apply()
     }
 
     /**
@@ -446,6 +463,11 @@ class GuardianViewModel(application: Application) : AndroidViewModel(application
             AppLogger.log("TIMER", "Timed deactivation: ${expired.keys}")
             expired.keys.forEach { modeId -> deactivateMode(modeId) }
         }
+    }
+
+    companion object {
+        /** Minimum (and default) anti-bypass challenge wait time, in seconds. */
+        const val CHALLENGE_MIN_SECONDS = 90
     }
 
 }

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/MainActivity.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -91,15 +92,9 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        // Notification permission (Android 13+) is a runtime permission, not a
-        // settings-page intent like the others, so we ask for it directly from
-        // the activity instead of going through the Compose onboarding flow.
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-                != android.content.pm.PackageManager.PERMISSION_GRANTED) {
-                requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), 1001)
-            }
-        }
+        // Notification permission (Android 13+) is requested as an explained,
+        // optional step inside the permission onboarding flow — not fired
+        // blindly at launch, where it lands before the user knows what it's for.
 
         handleNfcIntent(intent)
     }
@@ -230,6 +225,12 @@ fun MainNavigation(
         )
     }
 
+    // Back from a sub-screen returns to Home instead of exiting to the
+    // launcher. On Home, Back is left unhandled so the system exits normally.
+    BackHandler(enabled = hasSeenOnboarding && currentScreen != Screen.HOME) {
+        currentScreen = Screen.HOME
+    }
+
     Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
         if (!hasSeenOnboarding) {
             OnboardingScreen(
@@ -284,25 +285,39 @@ fun OnboardingScreen(onComplete: () -> Unit) {
         OnboardingPage(
             title = "MODES",
             subtitle = "FLEXIBLE CONTROL",
-            description = "Create blocking modes for different contexts:\n\n- BLOCK MODE - Block specific distracting apps\n- ALLOW MODE - Block everything except essential apps",
+            description = "Create blocking modes for any situation:\n\n" +
+                    "•  BLOCK — block the specific apps that distract you\n" +
+                    "•  ALLOW ONLY — block everything except the apps you choose",
             icon = "modes"
         ),
         OnboardingPage(
             title = "NFC LOCKS",
             subtitle = "PHYSICAL FRICTION",
-            description = "Optional: Require NFC tags to unlock modes.\n\nPlace tags in inconvenient locations (kitchen, gym, friend's house) to add intentional friction before accessing blocked apps.",
+            description = "Add NFC tags as physical keys to unlock your modes.\n\n" +
+                    "Keep a tag somewhere inconvenient — a drawer, the kitchen, another room — so opening a blocked app takes real, deliberate effort.\n\n" +
+                    "This is an optional extra layer; modes work fine without it.",
             icon = "nfc"
         ),
         OnboardingPage(
             title = "SCHEDULES",
             subtitle = "AUTOMATION",
-            description = "Set modes to activate automatically:\n\n- Weekday work hours (9am-5pm)\n- Sleep schedule (10pm-7am)\n- Weekend deep work sessions",
+            description = "Let modes turn on by themselves, on the days and times you set:\n\n" +
+                    "•  Work hours on weekdays\n" +
+                    "•  Sleep schedule overnight\n" +
+                    "•  Deep-work blocks on weekends",
             icon = "schedule"
         ),
         OnboardingPage(
             title = "READY",
             subtitle = "LET'S GET STARTED",
-            description = "Guardian needs a few permissions to work:\n\n- Usage access - Detect which apps you use\n- Display over apps - Show block screen\n- Battery optimization - Run reliably\n\nLet's set them up now.",
+            description = "Guardian needs a few permissions to do its job. We'll walk through each one and explain why:\n\n" +
+                    "•  Notifications (optional) — show which modes are active\n" +
+                    "•  Usage access — see which app is open\n" +
+                    "•  Display over apps — show the block screen\n" +
+                    "•  Battery optimization — keep running reliably\n" +
+                    "•  Pause app activity — must be turned off for Guardian\n" +
+                    "•  Accessibility — more reliable, instant blocking\n\n" +
+                    "Let's set them up.",
             icon = "ready"
         )
     )
@@ -484,15 +499,18 @@ fun OnboardingPageContent(page: OnboardingPage) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Description
+        // Description — left-aligned so multi-line bullet lists line up
+        // cleanly instead of rendering ragged under centered alignment.
         Text(
             page.description,
             fontSize = 14.sp,
             color = GuardianTheme.TextPrimary,
             letterSpacing = 0.5.sp,
             lineHeight = 22.sp,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 8.dp)
+            textAlign = TextAlign.Start,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
         )
     }
 }

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/home/HomeScreen.kt
@@ -9,6 +9,9 @@ import com.andebugulin.nfcguard.ui.GuardianTheme
 import com.andebugulin.nfcguard.ui.GuardianViewModel
 import com.andebugulin.nfcguard.ui.safety.SafeRegimeChallengeDialog
 import com.andebugulin.nfcguard.ui.Screen
+import com.andebugulin.nfcguard.ui.onboarding.FeatureShowcaseDialog
+import com.andebugulin.nfcguard.ui.onboarding.isShowcaseSeen
+import com.andebugulin.nfcguard.ui.onboarding.markShowcaseSeen
 
 import android.content.Context
 import android.content.Intent
@@ -56,6 +59,7 @@ fun HomeScreen(
     onNavigate: (Screen) -> Unit
 ) {
     val appState by viewModel.appState.collectAsState()
+    val challengeDuration by viewModel.challengeDurationSeconds.collectAsState()
     val context = LocalContext.current
 
     var showEmergencyDialog by remember { mutableStateOf(false) }
@@ -63,6 +67,21 @@ fun HomeScreen(
     var showTagSelectionDialog by remember { mutableStateOf(false) }
     var selectedTagsToDelete by remember { mutableStateOf(setOf<String>()) }
     var showSettingsDialog by remember { mutableStateOf(false) }
+    var showcaseFor by remember { mutableStateOf<Screen?>(null) }
+
+    // First-time entry to a section shows a one-off explainer, but only for a
+    // genuinely new user: that section has nothing configured AND the popup
+    // hasn't been seen. Otherwise navigate straight through.
+    val openSection: (Screen) -> Unit = { screen ->
+        val sectionEmpty = when (screen) {
+            Screen.MODES -> appState.modes.isEmpty()
+            Screen.SCHEDULES -> appState.schedules.isEmpty()
+            Screen.NFC_TAGS -> appState.nfcTags.isEmpty()
+            else -> false
+        }
+        if (sectionEmpty && !isShowcaseSeen(context, screen)) showcaseFor = screen
+        else onNavigate(screen)
+    }
 
     // Tick every 30s to keep timer countdowns fresh
     var timeTick by remember { mutableStateOf(0L) }
@@ -266,21 +285,21 @@ fun HomeScreen(
             title = "MODES",
             subtitle = "${appState.modes.size} CREATED",
             icon = Icons.Default.Block,
-            onClick = { onNavigate(Screen.MODES) }
+            onClick = { openSection(Screen.MODES) }
         )
 
         NavigationCard(
             title = "SCHEDULES",
             subtitle = "${appState.schedules.size} CONFIGURED",
             icon = Icons.Default.Schedule,
-            onClick = { onNavigate(Screen.SCHEDULES) }
+            onClick = { openSection(Screen.SCHEDULES) }
         )
 
         NavigationCard(
             title = "NFC TAGS",
             subtitle = "${appState.nfcTags.size} REGISTERED",
             icon = Icons.Default.Nfc,
-            onClick = { onNavigate(Screen.NFC_TAGS) }
+            onClick = { openSection(Screen.NFC_TAGS) }
         )
 
         Spacer(Modifier.weight(1f))
@@ -463,6 +482,7 @@ fun HomeScreen(
     if (showEmergencyChallenge) {
         SafeRegimeChallengeDialog(
             actionDescription = "Emergency reset will deactivate all modes and delete selected NFC tags. This could bypass the blocker.",
+            totalDurationSeconds = challengeDuration,
             onComplete = {
                 showEmergencyChallenge = false
                 showTagSelectionDialog = true
@@ -512,6 +532,17 @@ fun HomeScreen(
             onDismiss = {
                 showSettingsDialog = false
                 permissionCheckTrigger++ // recheck permissions when closing
+            }
+        )
+    }
+
+    showcaseFor?.let { screen ->
+        FeatureShowcaseDialog(
+            screen = screen,
+            onContinue = {
+                markShowcaseSeen(context, screen)
+                showcaseFor = null
+                onNavigate(screen)
             }
         )
     }
@@ -798,6 +829,9 @@ fun SettingsDialog(
     var pendingImportData by remember { mutableStateOf<ConfigManager.ExportData?>(null) }
     var showExportFormatChooser by remember { mutableStateOf(false) }
     var showImportChallenge by remember { mutableStateOf(false) }
+    val challengeDuration by viewModel.challengeDurationSeconds.collectAsState()
+    var showTestChallenge by remember { mutableStateOf(false) }
+    var showDurationPicker by remember { mutableStateOf(false) }
 
     // Auto-refresh permissions when activity resumes + periodic poll
     // (Battery optimization dialog stays in-app, so ON_RESUME doesn't fire for it)
@@ -1089,7 +1123,7 @@ fun SettingsDialog(
                             )
                             Spacer(Modifier.height(2.dp))
                             Text(
-                                if (safeRegimeEnabled) "Actions that could bypass blocking require a 5-minute attention challenge"
+                                if (safeRegimeEnabled) "Actions that could bypass blocking require a 1.5-minute attention challenge"
                                 else "Disabled — all actions are unrestricted",
                                 fontSize = 9.sp,
                                 color = GuardianTheme.TextTertiary,
@@ -1144,9 +1178,67 @@ fun SettingsDialog(
                     }
                 }
 
+                // Challenge duration — configurable, but never below 1:30
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(0.dp),
+                    color = GuardianTheme.BackgroundSurface,
+                    onClick = { showDurationPicker = true }
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                "CHALLENGE DURATION",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = GuardianTheme.TextPrimary,
+                                letterSpacing = 1.sp
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                "How long you must stay attentive (minimum 1:30)",
+                                fontSize = 9.sp,
+                                color = GuardianTheme.TextTertiary,
+                                letterSpacing = 0.3.sp
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            "${challengeDuration / 60}:${"%02d".format(challengeDuration % 60)}",
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Black,
+                            color = GuardianTheme.TextPrimary,
+                            letterSpacing = 1.sp
+                        )
+                    }
+                }
+
+                // Test the challenge without needing an active mode
+                Button(
+                    onClick = { showTestChallenge = true },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GuardianTheme.BackgroundSurface,
+                        contentColor = GuardianTheme.TextPrimary
+                    ),
+                    shape = RoundedCornerShape(0.dp),
+                    modifier = Modifier.fillMaxWidth().height(40.dp)
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.Shield, null, modifier = Modifier.size(16.dp))
+                        Text("TEST CHALLENGE", fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
+                    }
+                }
+
                 if (showSafeRegimeChallenge) {
                     SafeRegimeChallengeDialog(
                         actionDescription = "You are trying to disable Safe Regime while modes are active. This could allow bypassing the blocker.",
+                        totalDurationSeconds = challengeDuration,
                         onComplete = {
                             viewModel.setSafeRegimeEnabled(false)
                             showSafeRegimeChallenge = false
@@ -1415,12 +1507,34 @@ fun SettingsDialog(
     if (showImportChallenge) {
         SafeRegimeChallengeDialog(
             actionDescription = "Importing a config while modes are active could be used to bypass blocking. Verify your intent.",
+            totalDurationSeconds = challengeDuration,
             onComplete = {
                 showImportChallenge = false
                 importLauncher.launch(arrayOf("application/json", "application/x-yaml", "*/*"))
             },
             onCancel = {
                 showImportChallenge = false
+            }
+        )
+    }
+
+    // Let users feel the anti-bypass challenge without an active mode
+    if (showTestChallenge) {
+        SafeRegimeChallengeDialog(
+            actionDescription = "This is a practice run of the anti-bypass challenge. It's how Guardian protects sensitive actions while modes are active.",
+            totalDurationSeconds = challengeDuration,
+            onComplete = { showTestChallenge = false },
+            onCancel = { showTestChallenge = false }
+        )
+    }
+
+    if (showDurationPicker) {
+        ChallengeDurationDialog(
+            currentSeconds = challengeDuration,
+            onDismiss = { showDurationPicker = false },
+            onConfirm = { seconds ->
+                viewModel.setChallengeDurationSeconds(seconds)
+                showDurationPicker = false
             }
         )
     }
@@ -1564,4 +1678,103 @@ private fun PermissionRow(
             )
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChallengeDurationDialog(
+    currentSeconds: Int,
+    onDismiss: () -> Unit,
+    onConfirm: (Int) -> Unit
+) {
+    var mins by remember { mutableStateOf((currentSeconds / 60).toString()) }
+    var secs by remember { mutableStateOf((currentSeconds % 60).toString()) }
+    val total = (mins.toIntOrNull() ?: 0) * 60 + (secs.toIntOrNull() ?: 0)
+    val belowMin = total < 90
+
+    val fieldColors = OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = GuardianTheme.BorderFocused,
+        unfocusedBorderColor = GuardianTheme.BorderSubtle,
+        focusedTextColor = GuardianTheme.InputText,
+        unfocusedTextColor = GuardianTheme.InputText,
+        focusedLabelColor = GuardianTheme.TextSecondary,
+        unfocusedLabelColor = GuardianTheme.TextTertiary,
+        cursorColor = GuardianTheme.InputCursor
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = GuardianTheme.ButtonSecondary,
+        tonalElevation = 0.dp,
+        shape = RoundedCornerShape(0.dp),
+        modifier = Modifier.border(
+            width = GuardianTheme.DialogBorderWidth,
+            color = GuardianTheme.DialogBorderInfo,
+            shape = RoundedCornerShape(0.dp)
+        ),
+        title = {
+            Text(
+                "CHALLENGE DURATION",
+                fontWeight = FontWeight.Black,
+                letterSpacing = 2.sp,
+                color = GuardianTheme.TextPrimary,
+                fontSize = 14.sp
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "How long you must stay attentive before a bypass-risky action goes through. The minimum is 1:30 — you can make it longer, never shorter.",
+                    fontSize = 10.sp,
+                    color = GuardianTheme.TextSecondary,
+                    letterSpacing = 0.3.sp
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedTextField(
+                        value = mins,
+                        onValueChange = { mins = it.filter { c -> c.isDigit() }.take(2) },
+                        label = { Text("MIN", fontSize = 9.sp, letterSpacing = 1.sp) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                        colors = fieldColors,
+                        shape = RoundedCornerShape(0.dp)
+                    )
+                    Text(":", fontSize = 20.sp, fontWeight = FontWeight.Bold, color = GuardianTheme.TextPrimary)
+                    OutlinedTextField(
+                        value = secs,
+                        onValueChange = { secs = it.filter { c -> c.isDigit() }.take(2) },
+                        label = { Text("SEC", fontSize = 9.sp, letterSpacing = 1.sp) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                        colors = fieldColors,
+                        shape = RoundedCornerShape(0.dp)
+                    )
+                }
+                if (belowMin) {
+                    Text(
+                        "Minimum is 1:30",
+                        fontSize = 10.sp,
+                        color = GuardianTheme.Error,
+                        letterSpacing = 0.5.sp
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(total) }, enabled = !belowMin) {
+                Text("APPLY", fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                colors = ButtonDefaults.textButtonColors(contentColor = GuardianTheme.TextSecondary)
+            ) {
+                Text("CANCEL", letterSpacing = 1.sp)
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/nfc/NfcTagsScreen.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/nfc/NfcTagsScreen.kt
@@ -35,6 +35,7 @@ fun NfcTagsScreen(
     onBack: () -> Unit
 ) {
     val appState by viewModel.appState.collectAsState()
+    val challengeDuration by viewModel.challengeDurationSeconds.collectAsState()
     var showAddDialog by remember { mutableStateOf(false) }
     var pendingTagId by remember { mutableStateOf<String?>(null) }
     var editingTag by remember { mutableStateOf<NfcTag?>(null) }
@@ -309,14 +310,14 @@ fun NfcTagsScreen(
                         ) {
                             Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                 Text(
-                                    "ANTI-CHEAT PROTECTION:",
+                                    "ANTI-BYPASS PROTECTION:",
                                     fontSize = 11.sp,
                                     fontWeight = FontWeight.Black,
                                     color = GuardianTheme.Warning,
                                     letterSpacing = 1.sp
                                 )
                                 Text(
-                                    "This tag has active modes. Extra confirmation required to prevent cheating.",
+                                    "This tag has active modes. Extra confirmation is required to prevent bypassing the blocker.",
                                     fontSize = 11.sp,
                                     color = GuardianTheme.Warning,
                                     letterSpacing = 0.5.sp
@@ -396,6 +397,7 @@ fun NfcTagsScreen(
     if (showDeleteChallenge && pendingDeleteTag != null) {
         SafeRegimeChallengeDialog(
             actionDescription = "Deleting NFC tag ${pendingDeleteTag!!.name} while modes are active could make it impossible to deactivate them normally.",
+            totalDurationSeconds = challengeDuration,
             onComplete = {
                 pendingDeleteTag?.let { viewModel.deleteNfcTag(it.id) }
                 showDeleteChallenge = false

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/onboarding/FeatureShowcase.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/onboarding/FeatureShowcase.kt
@@ -1,0 +1,226 @@
+package com.andebugulin.nfcguard.ui.onboarding
+
+import com.andebugulin.nfcguard.ui.GuardianTheme
+import com.andebugulin.nfcguard.ui.Screen
+
+import android.content.Context
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Nfc
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+
+/**
+ * One-time, minimalist "what is this?" popup shown the first time a brand-new
+ * user opens Modes / Schedules / NFC Tags. Existing users (who already have
+ * items configured, or have seen the popup) never see it — gated by
+ * [isShowcaseSeen] plus an emptiness check at the call site.
+ */
+
+private const val PREFS = "guardian_prefs"
+
+private fun showcaseKeyFor(screen: Screen): String? = when (screen) {
+    Screen.MODES -> "showcase_modes"
+    Screen.SCHEDULES -> "showcase_schedules"
+    Screen.NFC_TAGS -> "showcase_nfc"
+    else -> null
+}
+
+fun isShowcaseSeen(context: Context, screen: Screen): Boolean {
+    val key = showcaseKeyFor(screen) ?: return true
+    return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getBoolean(key, false)
+}
+
+fun markShowcaseSeen(context: Context, screen: Screen) {
+    val key = showcaseKeyFor(screen) ?: return
+    context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(key, true).apply()
+}
+
+private data class ShowcaseContent(
+    val title: String,
+    val icon: ImageVector,
+    val body: String
+)
+
+@Composable
+fun FeatureShowcaseDialog(screen: Screen, onContinue: () -> Unit) {
+    val content = when (screen) {
+        Screen.MODES -> ShowcaseContent(
+            "MODES",
+            Icons.Default.Block,
+            "A mode is a set of apps to block. Create one, choose BLOCK (block the apps you pick) " +
+                "or ALLOW ONLY (block everything except the apps you pick), then activate it.\n\n" +
+                "You can turn a mode on manually, on a schedule, or lock it behind an NFC tag."
+        )
+        Screen.SCHEDULES -> ShowcaseContent(
+            "SCHEDULES",
+            Icons.Default.Schedule,
+            "Schedules turn your modes on and off automatically. Pick the days and times, link one " +
+                "or more modes, and Guardian handles the rest — for example, work hours on weekdays " +
+                "or a sleep schedule overnight."
+        )
+        Screen.NFC_TAGS -> ShowcaseContent(
+            "NFC TAGS",
+            Icons.Default.Nfc,
+            "Register an NFC tag as a physical key, then link it to a mode. You'll need to tap that " +
+                "tag to unlock the mode — real friction between you and a blocked app. Keep the tag " +
+                "somewhere inconvenient for the most effect."
+        )
+        else -> return
+    }
+
+    // Subtle scale + fade entrance — clean, not flashy.
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { visible = true }
+    val scale by animateFloatAsState(
+        targetValue = if (visible) 1f else 0.92f,
+        animationSpec = tween(220),
+        label = "showcaseScale"
+    )
+    val fade by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(220),
+        label = "showcaseAlpha"
+    )
+
+    Dialog(onDismissRequest = onContinue) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .graphicsLayer { scaleX = scale; scaleY = scale }
+                .alpha(fade)
+                .border(
+                    width = GuardianTheme.DialogBorderWidth,
+                    color = GuardianTheme.DialogBorderInfo,
+                    shape = RoundedCornerShape(0.dp)
+                ),
+            shape = RoundedCornerShape(0.dp),
+            color = GuardianTheme.ButtonSecondary
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Icon(
+                    content.icon,
+                    contentDescription = null,
+                    tint = GuardianTheme.IconPrimary,
+                    modifier = Modifier.size(40.dp)
+                )
+                Text(
+                    content.title,
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Black,
+                    letterSpacing = 2.sp,
+                    color = GuardianTheme.TextPrimary
+                )
+                Text(
+                    content.body,
+                    fontSize = 13.sp,
+                    color = GuardianTheme.TextSecondary,
+                    letterSpacing = 0.3.sp,
+                    lineHeight = 19.sp
+                )
+
+                if (screen == Screen.NFC_TAGS) {
+                    NfcShowcaseTips()
+                }
+
+                Button(
+                    onClick = onContinue,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GuardianTheme.ButtonPrimary,
+                        contentColor = GuardianTheme.ButtonPrimaryText
+                    ),
+                    shape = RoundedCornerShape(0.dp),
+                    modifier = Modifier.fillMaxWidth().height(48.dp)
+                ) {
+                    Text("GOT IT", fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NfcShowcaseTips() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(0.dp),
+        color = GuardianTheme.BackgroundSurface
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            TipRow(
+                Icons.Default.Delete,
+                "Lost a tag? Use Emergency Reset (the trash icon on the Home screen) to switch modes off and remove lost tags — no tag needed."
+            )
+            TipRow(
+                Icons.Default.Shield,
+                "Turn on Anti-Bypass Protection in Settings for an extra safety check before risky actions."
+            )
+            TipRow(
+                Icons.Default.BugReport,
+                "Found a bug? Report it from the Info (i) screen."
+            )
+        }
+    }
+}
+
+@Composable
+private fun TipRow(icon: ImageVector, text: String) {
+    Row(verticalAlignment = Alignment.Top) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = GuardianTheme.IconSecondary,
+            modifier = Modifier.size(14.dp)
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text,
+            fontSize = 10.sp,
+            color = GuardianTheme.TextTertiary,
+            letterSpacing = 0.3.sp,
+            lineHeight = 14.sp
+        )
+    }
+}

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/onboarding/PermissionOnboarding.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/onboarding/PermissionOnboarding.kt
@@ -1,13 +1,18 @@
 package com.andebugulin.nfcguard.ui.onboarding
 
+import android.Manifest
 import android.app.AppOpsManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
 import android.os.Process
 import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.compose.foundation.border
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -64,6 +69,8 @@ private data class PermissionRequest(
 
 private sealed interface OnboardingStep {
     data object Welcome : OnboardingStep
+    /** Android 13+ runtime notification prompt, shown with an explanation first. */
+    data object NotificationPermission : OnboardingStep
     data class GrantPermission(
         val current: PermissionRequest,
         val queue: List<PermissionRequest>
@@ -81,6 +88,13 @@ fun PermissionOnboarding(onDone: () -> Unit) {
     val context = LocalContext.current
     var step by remember { mutableStateOf<OnboardingStep?>(OnboardingStep.Welcome) }
 
+    // POST_NOTIFICATIONS is a runtime permission (not a Settings intent), so we
+    // request it through an Activity-result launcher after explaining why.
+    // Whatever the user chooses, we advance into the rest of the flow.
+    val notificationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { step = afterNotification(context) }
+
     when (val s = step) {
         null -> {
             // Flow finished — signal the host to drop us from composition.
@@ -97,6 +111,10 @@ fun PermissionOnboarding(onDone: () -> Unit) {
                 markInitialPermissionsGranted(context)
                 step = null
             }
+        )
+        OnboardingStep.NotificationPermission -> NotificationPermissionDialog(
+            onAllow = { notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) },
+            onSkip = { step = afterNotification(context) }
         )
         is OnboardingStep.GrantPermission -> GrantPermissionDialog(
             request = s.current,
@@ -153,11 +171,24 @@ fun PermissionOnboarding(onDone: () -> Unit) {
 // ─── State transitions ─────────────────────────────────────────────────────
 
 private fun nextAfterWelcome(context: Context): OnboardingStep? {
+    if (needsNotificationPermission(context)) return OnboardingStep.NotificationPermission
+    return afterNotification(context)
+}
+
+/** Continue past the (optional) notification step into the remaining permissions. */
+private fun afterNotification(context: Context): OnboardingStep? {
     val needed = computeNeededPermissions(context)
     return when {
         needed.isNotEmpty() -> OnboardingStep.GrantPermission(needed.first(), needed.drop(1))
         else -> nextAfterPermissionsExhausted(context)
     }
+}
+
+private fun needsNotificationPermission(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+    return ContextCompat.checkSelfPermission(
+        context, Manifest.permission.POST_NOTIFICATIONS
+    ) != PackageManager.PERMISSION_GRANTED
 }
 
 private fun advancePermissionQueue(queue: List<PermissionRequest>, context: Context): OnboardingStep? {
@@ -229,7 +260,7 @@ private fun computeNeededPermissions(context: Context): List<PermissionRequest> 
     if (!granted) {
         needed += PermissionRequest(
             "Usage Access",
-            "Required to detect which apps you're using",
+            "Lets Guardian see which app is currently open so it can block the right ones. It can't see anything inside your apps.",
             Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
         )
     }
@@ -238,7 +269,7 @@ private fun computeNeededPermissions(context: Context): List<PermissionRequest> 
     if (!Settings.canDrawOverlays(context)) {
         needed += PermissionRequest(
             "Display Over Apps",
-            "Required to show the block screen",
+            "Lets Guardian show the block screen on top of an app you've chosen to block.",
             Intent(
                 Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                 Uri.parse("package:${context.packageName}")
@@ -251,7 +282,7 @@ private fun computeNeededPermissions(context: Context): List<PermissionRequest> 
     if (!powerManager.isIgnoringBatteryOptimizations(context.packageName)) {
         needed += PermissionRequest(
             "Battery Optimization",
-            "Required to run reliably in the background",
+            "Stops Android from shutting Guardian down in the background, so blocking keeps working even after a while.",
             Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
                 .setData(Uri.parse("package:${context.packageName}"))
         )
@@ -269,16 +300,35 @@ private fun WelcomeDialog(
 ) {
     StyledDialog(
         title = "WELCOME TO GUARDIAN",
-        message = "Guardian needs the following permissions to protect your focus:\n\n" +
-            "• Notifications (optional) — display active modes\n" +
-            "• USAGE ACCESS — detect which apps you're using\n" +
-            "• DISPLAY OVER APPS — show the block screen\n" +
-            "• BATTERY OPTIMIZATION — run reliably in background\n" +
-            "• PAUSE APP ACTIVITY — must be disabled for Guardian\n" +
-            "• ACCESSIBILITY SERVICE — more reliable app detection\n\n" +
+        message = "To protect your focus, Guardian needs a few permissions. " +
+            "We'll go through them one at a time and explain each:\n\n" +
+            "• Notifications (optional) — show which modes are active\n" +
+            "• Usage access — see which app is open\n" +
+            "• Display over apps — show the block screen\n" +
+            "• Battery optimization — keep running reliably\n" +
+            "• Pause app activity — must be turned off for Guardian\n" +
+            "• Accessibility — more reliable, instant blocking\n\n" +
             "Let's set these up now.",
         confirmLabel = "CONTINUE",
         onConfirm = onContinue,
+        dismissLabel = "SKIP",
+        onDismiss = onSkip
+    )
+}
+
+@Composable
+private fun NotificationPermissionDialog(
+    onAllow: () -> Unit,
+    onSkip: () -> Unit
+) {
+    StyledDialog(
+        title = "NOTIFICATIONS (OPTIONAL)",
+        message = "Guardian can show a quiet notification with which modes are " +
+            "active and when a temporary unlock ends.\n\n" +
+            "This is optional — blocking works fine without it, and you can " +
+            "change it anytime in system settings.",
+        confirmLabel = "ALLOW",
+        onConfirm = onAllow,
         dismissLabel = "SKIP",
         onDismiss = onSkip
     )

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/safety/SafeRegimeChallengeDialog.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/safety/SafeRegimeChallengeDialog.kt
@@ -37,9 +37,9 @@ import kotlinx.coroutines.delay
 fun SafeRegimeChallengeDialog(
     actionDescription: String,
     onComplete: () -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    totalDurationSeconds: Int = 90 // default 1.5 minutes; configurable in Settings
 ) {
-    val totalDurationSeconds = 90 // 1.5 minutes
     val waitPhaseSeconds = 15     // seconds of passive waiting per cycle
     val checkPhaseSeconds = 5     // seconds the user has to press
 
@@ -50,7 +50,9 @@ fun SafeRegimeChallengeDialog(
     var completed by remember { mutableStateOf(false) }
     var checksCompleted by remember { mutableIntStateOf(0) }
 
-    val totalChecks = totalDurationSeconds / (waitPhaseSeconds + checkPhaseSeconds) // 20
+    // Note: the number of attention checks isn't fixed — pressing quickly fits
+    // more cycles into the total time — so we show checks *passed*, never a
+    // total to chase (a misleading "x / 4" let fast tappers overshoot to 5/4).
 
     // Main timer tick — 1 second resolution
     LaunchedEffect(failed, completed) {
@@ -72,7 +74,7 @@ fun SafeRegimeChallengeDialog(
                 }
             }
         }
-        // 5 minutes passed with all checks — success
+        // 1.5 minutes passed with all checks — success
         completed = true
         onComplete()
     }
@@ -217,7 +219,7 @@ fun SafeRegimeChallengeDialog(
                                 trackColor = GuardianTheme.ButtonDisabledContainer
                             )
                             Text(
-                                "CHECK $checksCompleted / $totalChecks",
+                                "CHECKS PASSED: $checksCompleted",
                                 fontSize = 10.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = GuardianTheme.TextSecondary,

--- a/app/src/main/java/com/andebugulin/nfcguard/ui/schedules/SchedulesScreen.kt
+++ b/app/src/main/java/com/andebugulin/nfcguard/ui/schedules/SchedulesScreen.kt
@@ -128,6 +128,7 @@ fun SchedulesScreen(
 ) {
     val appState by viewModel.appState.collectAsState()
     val safeRegimeEnabled by viewModel.safeRegimeEnabled.collectAsState()
+    val challengeDuration by viewModel.challengeDurationSeconds.collectAsState()
     var showAddDialog by remember { mutableStateOf(false) }
     var editingSchedule by remember { mutableStateOf<Schedule?>(null) }
     var showDeleteDialog by remember { mutableStateOf<Schedule?>(null) }
@@ -162,6 +163,7 @@ fun SchedulesScreen(
     if (showSafeRegimeChallenge) {
         SafeRegimeChallengeDialog(
             actionDescription = challengeDescription,
+            totalDurationSeconds = challengeDuration,
             onComplete = {
                 showSafeRegimeChallenge = false
                 pendingChallengeAction?.invoke()
@@ -1087,7 +1089,7 @@ fun ScheduleEditorDialog(
                                     ) {
                                         Icon(Icons.Default.Shield, null, tint = GuardianTheme.Warning, modifier = Modifier.size(14.dp))
                                         Text(
-                                            "Safe regime: saving will require a 5-min challenge",
+                                            "Safe regime: saving will require a 1.5-min challenge",
                                             fontSize = 9.sp,
                                             color = GuardianTheme.Warning,
                                             letterSpacing = 0.3.sp


### PR DESCRIPTION
Back navigation:
- BackHandler in MainNavigation so hardware/gesture Back returns to Home from sub-screens instead of exiting to the launcher.

Permissions & onboarding:
- Stop requesting POST_NOTIFICATIONS at launch; ask it as an explained, optional step inside PermissionOnboarding (Android 13+ runtime launcher).
- Rewrite intro pages (clearer NFC framing, Ready page lists every permission + why), left-align bullet copy, clearer permission reasons.

Anti-bypass challenge:
- Make the wait time configurable (prefs-backed) with a 1:30 floor, raise-only; add a duration picker and a TEST CHALLENGE button in Settings that runs without active modes.
- Thread the configured duration through every challenge call site.
- Show 'checks passed' instead of a misleading 'x / 4' total (fast tapping could overshoot the fixed count).

First-run showcase:
- New FeatureShowcase popups for Modes/Schedules/NFC, shown once to new users only (section empty and not yet seen); NFC popup points to Emergency Reset, Anti-Bypass Protection, and issue reporting.

Wording/accuracy:
- Correct stale '5-minute' challenge 'anti-cheat' to 'anti-bypass' for consistency.

Co-Authored-By: Claude Opus 4.8